### PR TITLE
Ajout du code postal de Saint-Pierre-et-Miquelon

### DIFF
--- a/add-list.csv
+++ b/add-list.csv
@@ -1,3 +1,5 @@
 nomCommune,codeCommune,codePostal,libelleAcheminement,commentaire
 Suzan,09304,09240,SUZAN,commune manquante dans le FIMOCT
 Paris 16e Arrondissement,75116,75116,PARIS 16,arrondissement avec code postal manquant dans le FIMOCT
+Saint-Pierre,97502,97500,SAINT PIERRE,commune absente du FIMOCT
+Miquelon-Langlade,97501,97500,MIQUELON LANGLADE,commune absente du FIMOCT


### PR DESCRIPTION
Le code postal des deux communes de Saint-Pierre-et-Miquelon n'est pas présent dans le FIMOCT qui ne couvre de toute façon pas ce territoire.
Par conséquent ce code postal est absent de la BAN, et les adresses de ce territoire n'en ont pas, ce qui a généré un incident avec l'API Adresse.