### PR TITLE
cog 2024 -  défusion haut talican

### DIFF
--- a/add-list.csv
+++ b/add-list.csv
@@ -3,5 +3,6 @@ Suzan,09304,09240,SUZAN,commune manquante dans le FIMOCT
 Paris 16e Arrondissement,75116,75116,PARIS 16,arrondissement avec code postal manquant dans le FIMOCT
 Saint-Pierre,97502,97500,SAINT PIERRE,commune absente du FIMOCT
 Miquelon-Langlade,97501,97500,MIQUELON LANGLADE,commune absente du FIMOCT
-Sainte-Florence,85212,85140,STE FLORENCE,commune absente du FIMOCT
-L'Oie,85165,85140,L OIE,commune absente du FIMOCT
+Sainte-Florence,85212,85140,STE FLORENCE,commune absente du FIMOCT 2023 (defusion 2024/01)
+L'Oie,85165,85140,L OIE,commune absente du FIMOCT 2023 (defusion 2024/01)
+Les Hauts-Talican,60694,60390,LES HAUTS TALICAN,commune absente du FIMOCT 2023 (defusion 2024/01)

--- a/add-list.csv
+++ b/add-list.csv
@@ -6,3 +6,4 @@ Miquelon-Langlade,97501,97500,MIQUELON LANGLADE,commune absente du FIMOCT
 Sainte-Florence,85212,85140,STE FLORENCE,commune absente du FIMOCT 2023 (defusion 2024/01)
 L'Oie,85165,85140,L OIE,commune absente du FIMOCT 2023 (defusion 2024/01)
 Les Hauts-Talican,60694,60390,LES HAUTS TALICAN,commune absente du FIMOCT 2023 (defusion 2024/01)
+Beaumont-les-Nonains,60054,60390,BEAUMONT LES NONAINS,correction libelle acheminement (defusion avce haut-talican)

--- a/ignore-list.csv
+++ b/ignore-list.csv
@@ -2,3 +2,4 @@ nomCommune,codeCommune,codePostal,commentaire
 Rochefort,17299,17133,
 Rochefort,17299,17134,
 Rochefort,17299,17135,
+Beaumont-les-Nonains,60054,60390,corrigé dans la add liste


### PR DESCRIPTION
[!IMPORTANT]
pré-requis #59 

# context
Les données étant sur le fimoct 2023, les données pour le cog 2024 ont des manques sur les communes defusionnées #56 .
La défusion des hauts-talican est particulière.

cette pr a pour but de renvoyer au mieux les infos sur le code commune 60054 (Beaumont-les-Nonains) et 60694 (les-hauts-talicans)

#  attendu en 2024:
```js
findCodePostal(60694)
```
```
{
  codePostal: '60390',
  libelleAcheminement: 'BEAUMONT LES NONAINS',
  codeCommune: '60054',
  nomCommune: 'Beaumont-les-Nonains'
}
```
```js
findCodePostal(60694)
```
```
  {
    codePostal: '60390',
    codeCommune: '60694',
    nomCommune: 'Les Hauts-Talican',
    libelleAcheminement: 'LES HAUTS TALICAN'
  }